### PR TITLE
Fix 16 false/unprovable theorem statements across test and valid splits

### DIFF
--- a/test/aime_1991_p9.v
+++ b/test/aime_1991_p9.v
@@ -6,9 +6,13 @@ Require Import ZArith.
 Open Scope R_scope.
 
 Theorem aime_1991_p9 :
-  forall (x : R) (m : Q),
+  forall (x : R),
+    cos x <> 0 ->
+    sin x <> 0 ->
     (1 / cos x + tan x = 22 / 7)%R ->
-    (1 / sin x + 1 / tan x = Q2R m)%R ->
-    (Qnum m + Zpos (Qden m))%Z = 44%Z.
+    (exists p q : Z, (0 < q)%Z /\ Z.gcd p q = 1%Z /\
+      (1 / sin x + 1 / tan x = IZR p / IZR q)%R /\
+      (p + q)%Z = 44%Z).
 
 Proof.
+Admitted.

--- a/test/aime_1994_p3.v
+++ b/test/aime_1994_p3.v
@@ -2,7 +2,7 @@ Require Import ZArith.
 Open Scope Z_scope.
 
 Theorem aime_1994_p3:
-  forall (x : Z) (f : Z -> Z),
-    (f x + f (x - 1) = x * x) -> (f 19 = 94) -> (f 94 mod 1000 = 561).
+  forall (f : Z -> Z),
+    (forall x, f x + f (x - 1) = x * x) -> (f 19 = 94) -> (f 94 mod 1000 = 561).
 Proof.
 Admitted.

--- a/test/algebra_apbmpcneq0_aeq0anbeq0anceq0.v
+++ b/test/algebra_apbmpcneq0_aeq0anbeq0anceq0.v
@@ -1,6 +1,6 @@
 Require Import Reals.Reals.
 Require Import QArith.QArith.
-Require Import QArith.Qreals.
+From Stdlib Require Import Qreals.
 
 Theorem algebra_apbmpcneq0_aeq0anbeq0anceq0:
   forall (a b c: Q) (m n: R),
@@ -8,6 +8,7 @@ Theorem algebra_apbmpcneq0_aeq0anbeq0anceq0:
     (Rpower m 3 = 2)%R ->
     (Rpower n 3 = 4)%R ->
     (Q2R a + Q2R b * m + Q2R c * n = 0)%R ->
-    a = 0%Q /\ b = 0%Q /\ c = 0%Q.
+    (a == 0)%Q /\ (b == 0)%Q /\ (c == 0)%Q.
 
 Proof.
+Admitted.

--- a/test/amc12a_2019_p12.v
+++ b/test/amc12a_2019_p12.v
@@ -5,6 +5,7 @@ Open Scope R_scope.
 
 Theorem amc12a_2019_p12:
   forall (x y : R),
+  0 < x -> 0 < y ->
   (x <> 1) /\ (y <> 1) ->
   (ln x / ln 2 = ln 16 / ln y) ->
   (x * y = 64) ->

--- a/test/amc12a_2020_p25.v
+++ b/test/amc12a_2020_p25.v
@@ -4,10 +4,10 @@ Require Import List.
 Open Scope R_scope.
 
 Theorem amc12a_2020_p25 :
-  forall (p q : nat), Nat.gcd p q = 1%nat ->
+  forall (p q : nat), (0 < q)%nat -> Nat.gcd p q = 1%nat ->
   forall (S : list R),
     (forall x : R, In x S <->
-      (IZR (Int_part x) * (x - IZR (Int_part x)) = INR p / INR q * Rpower x 2))
+      (0 < x /\ IZR (Int_part x) * (x - IZR (Int_part x)) = INR p / INR q * x^2))
     -> NoDup S
     -> fold_left Rplus S 0 = 420
     -> (p + q = 929)%nat.

--- a/test/amc12a_2021_p18.v
+++ b/test/amc12a_2021_p18.v
@@ -1,12 +1,14 @@
 Require Import Reals.
 Require Import QArith.
 Require Import Znumtheory.
-Require Import QArith.Qreals.
+From Stdlib Require Import Qreals.
 
 Theorem amc12a_2021_p18
   (f : Q -> R)
+  (hcompat : forall x y : Q, Qeq x y -> f x = f y)
   (h0 : forall x y : Q, (0 < x)%Q -> (0 < y)%Q -> f (Qmult x y) = Rplus (f x) (f y))
   (h1 : forall p : Z, prime p -> f (inject_Z p) = IZR p) :
   (f (Qmake 25 11) < 0)%R.
 
 Proof.
+Admitted.

--- a/test/imo_1982_p1.v
+++ b/test/imo_1982_p1.v
@@ -2,7 +2,8 @@ Require Import Arith.
 
 Theorem imo_1982_p1:
   forall (f : nat -> nat),
-  (forall m n, 0 < m -> 0 < n -> (f (m + n) - f m - f n = 0 \/ f (m + n) - f m - f n = 1)) ->
+  (forall m n, 0 < m -> 0 < n ->
+    (f (m + n) = f m + f n \/ f (m + n) = f m + f n + 1)) ->
   f 2 = 0 ->
   0 < f 3 ->
   f 9999 = 3333 ->

--- a/test/imo_2019_p1.v
+++ b/test/imo_2019_p1.v
@@ -3,6 +3,6 @@ Open Scope Z_scope.
 
 Theorem imo_2019_p1 (f : Z -> Z) :
   (forall a b, f (2 * a) + (2 * f b) = f (f (a + b))) <->
-  (forall z, f z = 0 \/ exists c, forall z, f z = 2 * z + c).
+  ((forall z, f z = 0) \/ exists c, forall z, f z = 2 * z + c).
 Proof.
 Admitted.

--- a/test/mathd_numbertheory_427.v
+++ b/test/mathd_numbertheory_427.v
@@ -15,7 +15,7 @@ Definition sum_list := fold_right plus 0.
 Definition is_prime (p : nat) :=
   match p with
   | 0 | 1 => false
-  | n => forallb (fun d => negb (Nat.eqb (n mod d) 0)) (seq 2 (pred n))
+  | n => forallb (fun d => negb (Nat.eqb (n mod d) 0)) (seq 2 (n - 2))
   end.
 
 Theorem mathd_numbertheory_427 :
@@ -24,3 +24,4 @@ Theorem mathd_numbertheory_427 :
   sum_list (filter (fun k => andb (is_prime k) (Nat.eqb (a mod k) 0)) (seq 1 (S a))) = 25.
 
 Proof.
+Admitted.

--- a/test/mathd_numbertheory_552.v
+++ b/test/mathd_numbertheory_552.v
@@ -13,7 +13,8 @@ Theorem mathd_numbertheory_552 :
     
     exists l : list nat,
       NoDup l /\
-      (forall y, In y l <-> exists x, h x = y) /\
+      (forall y, In y l <-> exists x, x > 0 /\ h x = y) /\
       List.fold_left Nat.add l 0 = 12.
 
 Proof.
+Admitted.

--- a/test/mathd_numbertheory_618.v
+++ b/test/mathd_numbertheory_618.v
@@ -5,7 +5,8 @@ Theorem mathd_numbertheory_618:
   forall n : nat,
   forall p : nat -> nat,
   (forall x, p x = x*x - x + 41) ->
+  0 < n ->
   1 < Nat.gcd (p n) (p (S n)) ->
-  41 <= n.
+  40 <= n.
 Proof.
 Admitted.

--- a/valid/aime_1984_p5.v
+++ b/valid/aime_1984_p5.v
@@ -3,6 +3,7 @@ Open Scope R_scope.
 
 Theorem aime_1984_p5 :
   forall a b : R,
+  0 < a -> 0 < b ->
   (ln a) / (ln 8) + (ln (b * b)) / (ln 4) = 5 ->
   (ln b) / (ln 8) + (ln (a * a)) / (ln 4) = 7 ->
   a * b = 512.

--- a/valid/mathd_algebra_190.v
+++ b/valid/mathd_algebra_190.v
@@ -1,6 +1,6 @@
 Require Import QArith.
 
 Theorem mathd_algebra_190 :
-  (3/8 + 7/8) / (4/5) = 25/16.
+  ((3/8 + 7/8) / (4/5) == 25/16)%Q.
 Proof.
 Admitted.

--- a/valid/mathd_numbertheory_126.v
+++ b/valid/mathd_numbertheory_126.v
@@ -1,11 +1,11 @@
 Require Import PeanoNat.
 
 Theorem mathd_numbertheory_126:
-  forall (x a : nat),
-  (0 < x) -> (0 < a) ->
-  (Nat.gcd a 40 = x + 3) ->
-  (Nat.lcm a 40 = x * (x + 3)) ->
-  (forall b : nat, (0 < b) -> (Nat.gcd b 40 = x + 3 /\ Nat.lcm b 40 = x * (x + 3) -> a <= b)) ->
+  forall (a : nat),
+  (0 < a) ->
+  (Nat.gcd a 40 = 8) ->
+  (Nat.lcm a 40 = 40) ->
+  (forall b : nat, (0 < b) -> (Nat.gcd b 40 = 8 /\ Nat.lcm b 40 = 40 -> a <= b)) ->
   a = 8.
 Proof.
 Admitted.

--- a/valid/mathd_numbertheory_780.v
+++ b/valid/mathd_numbertheory_780.v
@@ -1,9 +1,8 @@
-Require Import Nat.
 Require Import ZArith.
-Open Scope nat_scope.
+Open Scope Z_scope.
 
 Theorem mathd_numbertheory_780 :
-  forall m x : nat,
+  forall m x : Z,
     10 <= m ->
     m <= 99 ->
     (6 * x) mod m = 1 ->

--- a/valid/numbertheory_nckeqnm1ckpnm1ckm1.v
+++ b/valid/numbertheory_nckeqnm1ckpnm1ckm1.v
@@ -1,9 +1,11 @@
 Require Import Arith.
 
-Definition choose n k := fact n / (fact k * fact (n - k)).
+Definition choose n k :=
+  if k <=? n then fact n / (fact k * fact (n - k)) else 0.
 
 Theorem numbertheory_nckeqnm1ckpnm1ckm1 :
   forall (n k : nat),
     0 < k <= n ->
     choose n k = choose (n-1) k + choose (n-1) (k-1).
 Proof.
+Admitted.


### PR DESCRIPTION
Test split (11 files):
- mathd_numbertheory_618: add 0 < n guard, correct bound to 40
- aime_1994_p3: move forall x inside hypothesis
- mathd_numbertheory_427: fix is_prime divisor range (pred n -> n-2)
- mathd_numbertheory_552: restrict existential to x > 0
- amc12a_2021_p18: add Qeq-compatibility hypothesis
- algebra_apbmpcneq0: use Qeq (==) instead of Leibniz =
- amc12a_2019_p12: add 0 < x, 0 < y for ln
- aime_1991_p9: replace Q with R formulation, add trig guards
- imo_2019_p1: make disjunction global instead of pointwise
- imo_1982_p1: rewrite using addition to avoid nat subtraction
- amc12a_2020_p25: add 0 < x guard, use x^2 instead of Rpower

Valid split (5 files):
- numbertheory_nckeqnm1ckpnm1ckm1: guard choose for k > n
- aime_1984_p5: add 0 < a, 0 < b for ln
- mathd_numbertheory_780: use Z instead of nat
- mathd_numbertheory_126: instantiate x = 5
- mathd_algebra_190: use Qeq (==) instead of Leibniz =